### PR TITLE
Added parsing of the inflight adjustment events

### DIFF
--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -302,7 +302,7 @@ void onEvent(flightLog_t *log, flightLogEvent_t *event)
                 event->data.gtuneCycleResult.newP);
         break;
         case FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT:
-            fprintf(eventFile, "{\"name\":\"Inflight adjustment\", \"time\":%u, \"data\":{\"adjustmentFunction\":\"%s\",\"newValue\":", lastFrameTime,
+            fprintf(eventFile, "{\"name\":\"Inflight adjustment\", \"time\":%u, \"data\":{\"adjustmentFunction\":\"%s\",\"value\":", lastFrameTime,
                     INFLIGHT_ADJUSTMENT_FUNCTIONS[event->data.inflightAdjustment.adjustmentFunction & 127]);
             if (event->data.inflightAdjustment.adjustmentFunction > 127) {
                 fprintf(eventFile, "%g", event->data.inflightAdjustment.newFloatValue);

--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -104,6 +104,30 @@ static uint32_t bufferedFrameTime;
 
 static int32_t bufferedGPSFrame[FLIGHT_LOG_MAX_FIELDS];
 
+#define ADJUSTMENT_FUNCTION_COUNT 21
+static char *INFLIGHT_ADJUSTMENT_FUNCTIONS[ADJUSTMENT_FUNCTION_COUNT] = {
+        "NONE",
+        "RC_RATE",
+        "RC_EXPO",
+        "THROTTLE_EXPO",
+        "PITCH_ROLL_RATE",
+        "YAW_RATE",
+        "PITCH_ROLL_P",
+        "PITCH_ROLL_I",
+        "PITCH_ROLL_D",
+        "YAW_P",
+        "YAW_I",
+        "YAW_D",
+        "RATE_PROFILE",
+        "PITCH_RATE",
+        "ROLL_RATE",
+        "PITCH_P",
+        "PITCH_I",
+        "PITCH_D",
+        "ROLL_P",
+        "ROLL_I",
+        "ROLL_D"};
+
 static void fprintfMilliampsInUnit(FILE *file, int32_t milliamps, Unit unit)
 {
     switch (unit) {
@@ -276,7 +300,17 @@ void onEvent(flightLog_t *log, flightLogEvent_t *event)
                 event->data.gtuneCycleResult.axis,
                 event->data.gtuneCycleResult.gyroAVG,
                 event->data.gtuneCycleResult.newP);
-            break;
+        break;
+        case FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT:
+            fprintf(eventFile, "{\"name\":\"Inflight adjustment\", \"time\":%u, \"data\":{\"adjustmentFunction\":\"%s\",\"newValue\":", lastFrameTime,
+                    INFLIGHT_ADJUSTMENT_FUNCTIONS[event->data.inflightAdjustment.adjustmentFunction & 127]);
+            if (event->data.inflightAdjustment.adjustmentFunction > 127) {
+                fprintf(eventFile, "%g", event->data.inflightAdjustment.newFloatValue);
+            } else {
+                fprintf(eventFile, "%d", event->data.inflightAdjustment.newValue);
+            }
+            fprintf(eventFile, "}}\n");
+        break;
         case FLIGHT_LOG_EVENT_LOG_END:
             fprintf(eventFile, "{\"name\":\"Log clean end\", \"time\":%u}\n", lastFrameTime);
         break;

--- a/src/blackbox_fielddefs.h
+++ b/src/blackbox_fielddefs.h
@@ -131,6 +131,7 @@ typedef enum FlightLogEvent {
     FLIGHT_LOG_EVENT_AUTOTUNE_CYCLE_START = 10,
     FLIGHT_LOG_EVENT_AUTOTUNE_CYCLE_RESULT = 11,
     FLIGHT_LOG_EVENT_AUTOTUNE_TARGETS = 12,
+    FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT = 13,
     FLIGHT_LOG_EVENT_GTUNE_CYCLE_RESULT = 20,
     FLIGHT_LOG_EVENT_LOG_END = 255
 } FlightLogEvent;
@@ -170,6 +171,12 @@ typedef struct flightLogEvent_gtuneCycleResult_t {
     int16_t newP;
 } flightLogEvent_gtuneCycleResult_t;
 
+typedef struct flightLogEvent_inflightAdjustment_t {
+    uint8_t adjustmentFunction;
+    int32_t newValue;
+    float newFloatValue;
+} flightLogEvent_inflightAdjustment_t;
+
 typedef union flightLogEventData_t
 {
     flightLogEvent_syncBeep_t syncBeep;
@@ -177,6 +184,7 @@ typedef union flightLogEventData_t
     flightLogEvent_autotuneCycleResult_t autotuneCycleResult;
     flightLogEvent_autotuneTargets_t autotuneTargets;
     flightLogEvent_gtuneCycleResult_t gtuneCycleResult;
+    flightLogEvent_inflightAdjustment_t inflightAdjustment;
 } flightLogEventData_t;
 
 typedef struct flightLogEvent_t

--- a/src/parser.c
+++ b/src/parser.c
@@ -731,7 +731,7 @@ static void parseEventFrame(flightLog_t *log, mmapStream_t *stream, bool raw)
 
     char endMessage[END_OF_LOG_MESSAGE_LEN];
     (void) raw;
-
+    uint8_t adjustmentFunction;
     uint8_t eventType = streamReadByte(stream);
 
     flightLogEventData_t *data = &log->private->lastEvent.data;
@@ -765,6 +765,15 @@ static void parseEventFrame(flightLog_t *log, mmapStream_t *stream, bool raw)
             data->gtuneCycleResult.axis = streamReadByte(stream);
             data->gtuneCycleResult.gyroAVG = streamReadSignedVB(stream);
             data->gtuneCycleResult.newP = streamReadS16(stream);
+        break;
+        case FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT:
+             adjustmentFunction = streamReadByte(stream);
+             data->inflightAdjustment.adjustmentFunction = adjustmentFunction;
+             if (adjustmentFunction > 127) {
+                 data->inflightAdjustment.newFloatValue = streamReadRawFloat(stream);
+             } else {
+                 data->inflightAdjustment.newValue = streamReadSignedVB(stream);
+             }
         break;
         case FLIGHT_LOG_EVENT_LOG_END:
             streamRead(stream, endMessage, END_OF_LOG_MESSAGE_LEN);

--- a/src/parser.c
+++ b/src/parser.c
@@ -731,7 +731,6 @@ static void parseEventFrame(flightLog_t *log, mmapStream_t *stream, bool raw)
 
     char endMessage[END_OF_LOG_MESSAGE_LEN];
     (void) raw;
-    uint8_t adjustmentFunction;
     uint8_t eventType = streamReadByte(stream);
 
     flightLogEventData_t *data = &log->private->lastEvent.data;
@@ -767,9 +766,8 @@ static void parseEventFrame(flightLog_t *log, mmapStream_t *stream, bool raw)
             data->gtuneCycleResult.newP = streamReadS16(stream);
         break;
         case FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT:
-             adjustmentFunction = streamReadByte(stream);
-             data->inflightAdjustment.adjustmentFunction = adjustmentFunction;
-             if (adjustmentFunction > 127) {
+             data->inflightAdjustment.adjustmentFunction = streamReadByte(stream);
+             if (data->inflightAdjustment.adjustmentFunction > 127) {
                  data->inflightAdjustment.newFloatValue = streamReadRawFloat(stream);
              } else {
                  data->inflightAdjustment.newValue = streamReadSignedVB(stream);


### PR DESCRIPTION
Added support for inflight adjustment functions.

The events are logged to csv file as:

{"name":"Inflight adjustment", "time":51066286, "data":{"adjustmentFunction":"YAW_I","value":0.49}}

The example log file (with floats and integer values) and produced csv files are available here

https://www.dropbox.com/s/490s67w0l2xyiiv/test-log.zip?dl=1
