### PR TITLE
Fixed sign of some GPS co-ordinates when writing

### DIFF
--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -426,6 +426,9 @@ static void updateSimulations(flightLog_t *log, int32_t *frame, uint32_t current
  */
 void outputGPSFields(flightLog_t *log, FILE *file, int32_t *frame)
 {
+    char negSign[] = "-";
+    char noSign[] = "";
+
     int i;
     int32_t degrees;
     uint32_t fracDegrees;
@@ -445,8 +448,8 @@ void outputGPSFields(flightLog_t *log, FILE *file, int32_t *frame)
             case GPS_FIELD_TYPE_COORDINATE_DEGREES_TIMES_10000000:
                 degrees = frame[i] / 10000000;
                 fracDegrees = abs(frame[i]) % 10000000;
-
-                fprintf(file, "%d.%07u", degrees, fracDegrees);
+		char *sign = ((frame[i] < 0) && (degrees == 0)) ? negSign : noSign;
+                fprintf(file, "%s%d.%07u", sign, degrees, fracDegrees);
             break;
             case GPS_FIELD_TYPE_DEGREES_TIMES_10:
                 fprintf(file, "%d.%01u", frame[i] / 10, abs(frame[i]) % 10);

--- a/src/gpxwriter.c
+++ b/src/gpxwriter.c
@@ -29,6 +29,9 @@ void gpxWriterAddPreamble(gpxWriter_t *gpx)
  */
 void gpxWriterAddPoint(gpxWriter_t *gpx, uint32_t time, int32_t lat, int32_t lon, int16_t altitude)
 {
+    char negSign[] = "-";
+    char noSign[] = "";
+
     if (!gpx)
         return;
 
@@ -46,7 +49,11 @@ void gpxWriterAddPoint(gpxWriter_t *gpx, uint32_t time, int32_t lat, int32_t lon
     uint32_t latFracDegrees = abs(lat) % GPS_DEGREES_DIVIDER;
     uint32_t lonFracDegrees = abs(lon) % GPS_DEGREES_DIVIDER;
 
-    fprintf(gpx->file, "  <trkpt lat=\"%d.%07u\" lon=\"%d.%07u\"><ele>%d</ele>", latDegrees, latFracDegrees, lonDegrees, lonFracDegrees, altitude);
+    char *latSign = ((lat < 0) && (latDegrees == 0)) ? negSign : noSign;
+    char *lonSign = ((lon < 0) && (lonDegrees == 0)) ? negSign : noSign;
+
+    fprintf(gpx->file, "  <trkpt lat=\"%s%d.%07u\" lon=\"%s%d.%07u\"><ele>%d</ele>", latSign, latDegrees, latFracDegrees, lonSign, lonDegrees, lonFracDegrees, altitude);
+    
     if (time != (uint32_t) -1) {
         //We'll just assume that the timespan is less than 24 hours, and make up a date
         int hours, mins, secs, frac;


### PR DESCRIPTION
If the GPS co-ordinate is negative, but the number of degrees are zero, then the minus sign is omitted. This fixes the issue in both the .gpx and the .csv outputs.

(For info, I live in the UK and my longitude is -0.5 degrees - i.e. 0.5 deg W)
